### PR TITLE
fix parsing external network

### DIFF
--- a/compose_viz/spec/compose_spec.py
+++ b/compose_viz/spec/compose_spec.py
@@ -417,7 +417,7 @@ class Network(BaseModel):
     driver: Optional[str] = None
     driver_opts: Optional[Dict[str, Union[str, float]]] = None
     ipam: Optional[Ipam] = None
-    external: Optional[ExternalVolumeNetwork] = None
+    external: Optional[bool] = None
     internal: Optional[bool] = None
     enable_ipv6: Optional[bool] = None
     attachable: Optional[bool] = None

--- a/tests/ymls/networks/docker-compose.yml
+++ b/tests/ymls/networks/docker-compose.yml
@@ -26,3 +26,5 @@ networks:
   front-tier:
   back-tier:
   admin:
+    name: admin-network
+    external: true


### PR DESCRIPTION
- [x] Make admin network external in test case
- [x] Make the `external` attribute of a `Network` be an `Optional` boolean

resolves #57