### PR TITLE
fix(python 3.11): Python 3.11+ changed __str__ for enums

### DIFF
--- a/compose_viz/models/viz_formats.py
+++ b/compose_viz/models/viz_formats.py
@@ -43,3 +43,8 @@ class VizFormats(str, Enum):
     xdot1_2 = "xdot1.2"
     xdot1_4 = "xdot1.4"
     xdot_json = "xdot_json"
+
+    def __str__(self):
+        # Python 3.11+ broken __str__
+        # https://github.com/python/cpython/issues/100458
+        return self.name


### PR DESCRIPTION
**Context**: UTests are not running properly with python 3.11 because `__str__` has changed for enums with recent python versions as described here: https://github.com/python/cpython/issues/100458

**Solution**: re-implement `__str__` to be backwards compatible and avoid formats being serialized as `VizFormats.png` for instance

Will fix https://github.com/compose-viz/compose-viz/issues/98