### PR TITLE
fix: volumes.<volume_name>.external incorrect spec

### DIFF
--- a/compose_viz/spec/compose_spec.py
+++ b/compose_viz/spec/compose_spec.py
@@ -390,16 +390,6 @@ class ExternalVolumeNetwork(BaseModel):
     )
 
 
-class External1(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    name: Optional[str] = Field(
-        None,
-        description="Specifies the name of the external volume. Deprecated: use the 'name' property instead.",
-    )
-
-
 class ExternalConfig(BaseModel):
     name: Optional[str] = Field(None, description="Specifies the name of the external secret.")
 
@@ -740,7 +730,7 @@ class Volume(BaseModel):
     name: Optional[str] = Field(None, description="Custom name for this volume.")
     driver: Optional[str] = Field(None, description="Specify which volume driver should be used for this volume.")
     driver_opts: Optional[Dict[str, Union[str, float]]] = Field(None, description="Specify driver-specific options.")
-    external: Optional[External1] = Field(
+    external: Optional[bool] = Field(
         None,
         description="Specifies that this volume already exists and was created outside of Compose.",
     )

--- a/tests/ymls/volumes/docker-compose.yml
+++ b/tests/ymls/volumes/docker-compose.yml
@@ -26,3 +26,5 @@ services:
 volumes:
   common-volume:
   cli-volume:
+    # https://docs.docker.com/reference/compose-file/volumes/#external
+    external: true


### PR DESCRIPTION
**Context**: specification is not correct and did assume that extenal should be an object while it is an optional bool as described in https://docs.docker.com/reference/compose-file/volumes/#external

**Solution**: added a UTest to ensure it is working and fix the spec to be compliant with Docker compose specification

This will ensure that rendering of docker compose files with volumes.<volume_name>.external actually works