### PR TITLE
fix(expose): handle expose ports as int, not float

### DIFF
--- a/compose_viz/parser.py
+++ b/compose_viz/parser.py
@@ -239,7 +239,9 @@ class Parser:
             expose: List[str] = []
             if service_data.expose is not None:
                 for port in service_data.expose:
-                    expose.append(str(port))
+                    # to avoid to have values like 8885.0 for instance, cast floats into int first
+                    port_str = str(int(port)) if isinstance(port, float) else str(port)
+                    expose.append(port_str)
 
             profiles: List[str] = []
             if service_data.profiles is not None:

--- a/compose_viz/spec/compose_spec.py
+++ b/compose_viz/spec/compose_spec.py
@@ -974,7 +974,7 @@ class Service(BaseModel):
         None,
         description="Add environment variables. You can use either an array or a list of KEY=VAL pairs.",
     )
-    expose: Optional[List[Union[str, float]]] = Field(
+    expose: Optional[List[Union[str, int]]] = Field(
         None,
         description="Expose ports without publishing them to the host machine - they'll only be accessible to linked services.",
     )


### PR DESCRIPTION
**Context**: in some cases, ports were parsed (and rendered) as float, so, value float(8885) was renderered as 8885.0 for instance

**Solution**: Since a port is an int 0-65535, use an int not a float, so rendering will be OK